### PR TITLE
Add Mysql slow log commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- tasks around MySQL slow log
+
 ### Fixed
 - set group permissions for /var/www in Chef cookbook (Vagrant)
 - set proper gem homepage

--- a/config/vm/cookbooks/dkdeploy-core/recipes/default.rb
+++ b/config/vm/cookbooks/dkdeploy-core/recipes/default.rb
@@ -22,6 +22,18 @@ mysql_service 'default' do
   # Need for remote connection
   bind_address '0.0.0.0'
   action [:create, :start]
+  run_group 'vagrant'
+  run_user 'vagrant'
+end
+
+mysql_config 'default' do
+  instance 'default' # necessary in some cases, causes hanging on provisioning https://github.com/chef-cookbooks/mysql/issues/387
+  # use different user to allow capistrano access to log file
+  owner 'vagrant'
+  group 'vagrant'
+  source 'my_extra_settings.erb'
+  notifies :restart, 'mysql_service[default]'
+  action :create
 end
 
 mysql2_chef_gem 'default' do

--- a/config/vm/cookbooks/dkdeploy-core/templates/my_extra_settings.erb
+++ b/config/vm/cookbooks/dkdeploy-core/templates/my_extra_settings.erb
@@ -1,0 +1,6 @@
+[mysqld]
+# configure mysql to produce log with slow queries
+# log-output                     = /var/log/mysql-default/
+slow_query_log                 = 1
+# log file - needs to match :mysql_slow_log in deploy.rb of fixture
+slow_query_log_file            = /var/log/mysql-default/slow-queries.log

--- a/features/mysql.feature
+++ b/features/mysql.feature
@@ -1,0 +1,27 @@
+Feature: Test tasks for namespace 'mysql'
+
+  Background:
+    Given a test app with the default configuration
+    And the remote server is cleared
+    And I want to use the database `dkdeploy_core`
+
+  Scenario: Downloading the MYSQL slow log
+    When I successfully run `cap dev "db:upload_settings[127.0.0.1,3306,dkdeploy_core,root,ilikerandompasswords,utf8]"`
+    And I successfully run `cap dev "db:update[temp,dkdeploy_core.sql.gz]"`
+    And I successfully run `cap dev db:download_content`
+    And I successfully run `cap dev mysql:download_slow_log`
+    Then a file named "temp/slow-queries.dev.dkdeploy-core.dev.log" should exist
+
+  Scenario: Downloading the MYSQL slow log analyze file
+    When I successfully run `cap dev "db:upload_settings[127.0.0.1,3306,dkdeploy_core,root,ilikerandompasswords,utf8]"`
+    And I successfully run `cap dev "db:update[temp,dkdeploy_core.sql.gz]"`
+    And I successfully run `cap dev db:download_content`
+    And I successfully run `cap dev mysql:analyze_download_slow_log`
+    Then a file named "temp/mysql_slow_log_analyze.dev.dkdeploy-core.dev.log" should exist
+
+  Scenario: Clearing the MySQL slow log file
+    When I successfully run `cap dev "db:upload_settings[127.0.0.1,3306,dkdeploy_core,root,ilikerandompasswords,utf8]"`
+    And I successfully run `cap dev "db:update[temp,dkdeploy_core.sql.gz]"`
+    And I successfully run `cap dev db:download_content`
+    And I successfully run `cap dev mysql:clear_slow_log`
+    Then the output should match /has been cleared/

--- a/lib/capistrano/dkdeploy/core.rb
+++ b/lib/capistrano/dkdeploy/core.rb
@@ -15,6 +15,7 @@ load File.expand_path('../../../dkdeploy/tasks/db.rake', __FILE__)
 load File.expand_path('../../../dkdeploy/tasks/enhanced_symlinks.rake', __FILE__)
 load File.expand_path('../../../dkdeploy/tasks/current_folder.rake', __FILE__)
 load File.expand_path('../../../dkdeploy/tasks/bower.rake', __FILE__)
+load File.expand_path('../../../dkdeploy/tasks/mysql.rake', __FILE__)
 
 # Hook into symlink related tasks
 after 'deploy:check:linked_dirs', 'deploy:enhanced_symlinks:check:linked_dirs'
@@ -84,5 +85,8 @@ namespace :load do
 
     # Airbrush configuration
     set :format_options, command_output: true, log_file: nil, truncate: false
+
+    # MySQL slow_log
+    set :mysql_slow_log, ''
   end
 end

--- a/lib/dkdeploy/helpers/mysql.rb
+++ b/lib/dkdeploy/helpers/mysql.rb
@@ -1,0 +1,17 @@
+include Capistrano::DSL
+
+module Dkdeploy
+  module Helpers
+    # Helpers for MySQL slow_log tasks
+    module MySQL
+      # checks for existence of mysql_sloq_log on server and prints error message if not present
+      # @param file_path [String]
+      # @return [Boolean]
+      def slow_log_exists?(file_path)
+        return true if !file_path.empty? && test("[ -f #{file_path} ]")
+        error I18n.t('file.not_exists_or_not_accessible_on_host', file: file_path, host: server, scope: :dkdeploy)
+        false
+      end
+    end
+  end
+end

--- a/lib/dkdeploy/i18n.rb
+++ b/lib/dkdeploy/i18n.rb
@@ -3,9 +3,11 @@ require 'i18n'
 en = {
   file: {
     not_exists: 'File %{file} does not exist.',
+    not_exists_or_not_accessible_on_host: 'File %{file} does not exist on host %{host} or is not accessible.',
     not_exists_on_host: 'File %{file} does not exit on host %{host}.',
     upload: 'Uploading %{file} to %{target}.',
     download: 'Downloading %{file} to %{target}.',
+    download_from_host: 'Downloading %{file} to %{target} from %{host}.',
     copy: 'Copying %{file} to %{target}.',
     remove: 'Removing %{path}.'
   },
@@ -106,6 +108,10 @@ en = {
       enabled: 'The %{mode} maintenance mode has successfully been enabled.',
       disabled: 'The %{mode} maintenance mode has successfully been disabled.',
       can_not_disable_by_reason_of_permanent: "Maintenance permanent mode has been enabled. Please call the task 'maintenance:disable_permanent'."
+    },
+    mysql: {
+      clear_slow_log: 'MySQL slow log file %{file} on host %{host} has been cleared',
+      analyze_slow_log: 'Generating slow log analyze file for host %{host)'
     },
     project_version: {
       update: {

--- a/lib/dkdeploy/tasks/mysql.rake
+++ b/lib/dkdeploy/tasks/mysql.rake
@@ -1,0 +1,52 @@
+require 'dkdeploy/constants'
+require 'dkdeploy/helpers/common'
+require 'dkdeploy/helpers/mysql'
+
+include Dkdeploy::Constants
+include Dkdeploy::Helpers::Common
+include Dkdeploy::Helpers::MySQL
+include Capistrano::DSL
+
+namespace :mysql do
+  desc 'Clear slow log file'
+  task :clear_slow_log do
+    mysql_slow_log = fetch(:mysql_slow_log, '')
+    on roles :db do |server|
+      next unless slow_log_exists? mysql_slow_log
+      execute :echo, '', '>', mysql_slow_log
+      info I18n.t('tasks.mysql.clear_slow_log', file: mysql_slow_log, host: server, scope: :dkdeploy)
+    end
+  end
+
+  desc 'Download slow log file to temp/'
+  task :download_slow_log do
+    mysql_slow_log = fetch(:mysql_slow_log, '')
+    on roles :db do |server|
+      next unless slow_log_exists? mysql_slow_log
+      local_filename = File.join(local_dump_path, "#{File.basename(mysql_slow_log, '.*')}.#{fetch(:stage)}.#{server.hostname}#{File.extname(mysql_slow_log)}")
+      info I18n.t('file.download', file: mysql_slow_log, target: local_filename, host: server)
+      execute :mkdir, '-p', local_dump_path
+      download! mysql_slow_log, local_filename, via: :scp
+    end
+  end
+
+  desc 'Download slow log file to temp'
+  task :analyze_download_slow_log do
+    mysql_slow_log = fetch(:mysql_slow_log, '')
+    on roles :db do |server|
+      next unless slow_log_exists? mysql_slow_log
+      analyze_filename = "mysql_slow_log_analyze.#{fetch(:stage)}.#{server.hostname}.log"
+      remote_filename = File.join(deploy_path, analyze_filename)
+      local_filename = File.join(local_dump_path, analyze_filename)
+      # delete file, if exist
+      execute :rm, '-f', remote_filename
+      info I18n.t('tasks.mysql.analyze_slow_log', host: server, scope: :dkdeploy)
+      execute :mysqldumpslow, '-s', 't', mysql_slow_log, '>', remote_filename
+      execute :mkdir, '-p', local_dump_path
+      info I18n.t('file.download', file: remote_filename, target: local_filename, host: server)
+      download! remote_filename, local_filename, via: :scp
+      # delete file, if exist
+      execute :rm, '-f', remote_filename
+    end
+  end
+end

--- a/spec/fixtures/application/config/deploy/dev.rb
+++ b/spec/fixtures/application/config/deploy/dev.rb
@@ -1,5 +1,5 @@
 set :deploy_to, '/var/www/dkdeploy'
-server 'dkdeploy-core.dev', roles: %w(web app backend), primary: true
+server 'dkdeploy-core.dev', roles: %w(web app backend db), primary: true
 
 # no ssh compression on the dev stage
 set :ssh_options, {
@@ -33,3 +33,6 @@ set :default_file_access_owner_of_release_path, 'vagrant'
 
 set :default_file_access_group_of_shared_path, 'vagrant'
 set :default_file_access_group_of_release_path, 'vagrant'
+
+# mysql slow query log for performance analysis
+set :mysql_slow_log, '/var/log/mysql-default/slow-queries.log'


### PR DESCRIPTION
# Summary

This Pull Request adds three tasks to assist in MySQL performance analysis.
- `download_slow_log`
- `analyze_download_slow_log`
- `clear_slow_log`

These three tasks access the `:mysql_slow_log` variable which has to be set in the configuration of a project.
# Test Plan:
- reprovision test VM (maybe even build it new)
- run `cucumber`
