### PR TITLE
print error message in InteractionHandler

### DIFF
--- a/features/db.feature
+++ b/features/db.feature
@@ -91,3 +91,7 @@ Feature: Test tasks for namespace 'db'
 		And I successfully run `cap dev db:add_default_content`
 		And I wait 5 second to let the database commit the transaction
 		Then the database should have a value `first preseed value` in table `preseed_table` for column `value`
+
+	Scenario: Check error answer of a broken SQL syntax
+		When I run `cap dev "db:sql_error"`
+		Then the output should match /ERROR 1064/

--- a/lib/dkdeploy/interaction_handler/mysql.rb
+++ b/lib/dkdeploy/interaction_handler/mysql.rb
@@ -1,0 +1,37 @@
+module Dkdeploy
+  module InteractionHandler
+    # Interaction handler for sending password to MySQL client
+    # This InteractionHandler provides output of the error code if MySQL
+    # answers with an error to the command.
+    #
+    # @attr [String] password The password to send to terminal
+    class MySql
+      def initialize(password)
+        @password = password
+        # these two are declared as instance variables because the on_data method is called multiple times
+        @return_message = ''
+        @mysql_error_seen = false
+      end
+
+      # Method to send password to terminal
+      #
+      # @param [SSHKit::Command] _command
+      # @param [Symbol] _stream_name
+      # @param [String] data
+      # @param [Net::SSH::Connection::Channel] channel
+      def on_data(_command, _stream_name, data, channel)
+        if data =~ /.*password.*/i
+          channel.send_data("#{@password}\n")
+        else
+          @mysql_error_seen = true if data =~ /.*ERROR.*/i
+          return raise 'Unexpected data from stream. Can not send password to undefined stream' unless @mysql_error_seen
+          # combine the multiple lines from error message. The fact that the error message will be shown multiple times is simply ignored
+          @return_message << data
+          message = 'Error on executing MySQL command! Response (error code) is: '
+          SSHKit.config.output.send(:error, "#{message}\n         #{@return_message}")
+          raise 'InteractionHandler caught a MySQL error'
+        end
+      end
+    end
+  end
+end

--- a/lib/dkdeploy/tasks/db.rake
+++ b/lib/dkdeploy/tasks/db.rake
@@ -51,7 +51,7 @@ namespace :db do
         execute :mysql,
                 '-u', fetch(:db_username),
                 '-p', '-h', fetch(:db_host), '-P', fetch(:db_port), '-e', 'exit',
-                interaction_handler: Dkdeploy::InteractionHandler::Password.new(fetch(:db_password))
+                interaction_handler: Dkdeploy::InteractionHandler::MySql.new(fetch(:db_password))
       rescue SSHKit::Command::Failed
         error I18n.t('errors.connection_failed', scope: :dkdeploy)
         exit 1
@@ -92,7 +92,7 @@ namespace :db do
                 '-p',
                 '-h', db_settings.fetch('host'), '-P', db_settings.fetch('port'), db_settings.fetch('name'),
                 '-e', "'source #{remote_file_name}'",
-                interaction_handler: Dkdeploy::InteractionHandler::Password.new(db_settings.fetch('password'))
+                interaction_handler: Dkdeploy::InteractionHandler::MySql.new(db_settings.fetch('password'))
       ensure
         execute :rm, '-f', remote_zipped_file_name
         execute :rm, '-f', remote_file_name
@@ -256,7 +256,7 @@ namespace :db do
                 '-p',
                 '-h', db_settings.fetch('host'), '-P', db_settings.fetch('port'), db_settings.fetch('name'),
                 '-e', "'source #{remote_default_content_file}'",
-                interaction_handler: Dkdeploy::InteractionHandler::Password.new(db_settings.fetch('password'))
+                interaction_handler: Dkdeploy::InteractionHandler::MySql.new(db_settings.fetch('password'))
       ensure
         execute :rm, '-f', remote_default_content_file
         execute :rm, '-f', remote_zipped_default_content_file
@@ -282,7 +282,7 @@ namespace :db do
                 '-u', db_settings.fetch('username'), '-p',
                 '-h', db_settings.fetch('host'), '-P', db_settings.fetch('port'), db_settings.fetch('name'),
                 '-e', "'source #{remote_default_structure_file}'",
-                interaction_handler: Dkdeploy::InteractionHandler::Password.new(db_settings.fetch('password'))
+                interaction_handler: Dkdeploy::InteractionHandler::MySql.new(db_settings.fetch('password'))
       ensure
         execute :rm, '-f', remote_default_structure_file
         execute :rm, '-f', remote_zipped_default_structure_file
@@ -390,7 +390,7 @@ namespace :db do
                 '-p',
                 '-h', db_settings.fetch('host'), '-P', db_settings.fetch('port'), db_settings.fetch('name'),
                 '-e', "'source #{remote_dump_file}'",
-                interaction_handler: Dkdeploy::InteractionHandler::Password.new(db_settings.fetch('password'))
+                interaction_handler: Dkdeploy::InteractionHandler::MySql.new(db_settings.fetch('password'))
       end
     rescue SSHKit::Command::Failed => exception
       run_locally do

--- a/spec/fixtures/application/config/deploy.rb
+++ b/spec/fixtures/application/config/deploy.rb
@@ -11,8 +11,45 @@ set :asset_exclude_file, 'config/assets_exclude_file.txt'
 
 set :format_options, command_output: true
 set :log_level, :debug
-set :format, :pretty
 
 set :asset_default_content, %w[fileadmin uploads]
 set :asset_exclude_file, 'config/assets_exclude_file.txt'
 set :asset_folders, %w[fileadmin uploads]
+
+require 'dkdeploy/interaction_handler/mysql'
+namespace :db do
+  task :sql_error do
+    remote_db_file_path = File.join(shared_path, 'config')
+    remote_db_file = File.join(remote_db_file_path, 'broken.sql')
+    username = 'test_user'
+    password = "+p_secure[7Bvery_muchTL[E8yAGkMRT'A "
+    now = Time.now.to_i
+    sql_string = StringIO.new "INSERT INTO be_users (username, password, admin, tstamp, crdate)
+                                VALUES ('#{username}', MD5('#{password}'), 1, #{now}, #{now});"
+    on primary :backend do
+      begin
+        db_settings = {
+          charset: 'utf8',
+          username: 'root',
+          password: 'ilikerandompasswords',
+          host: '127.0.0.1',
+          port: 3306,
+          name: 'dkdeploy_core'
+        }
+        execute :mkdir, '-p', remote_db_file_path
+        execute :rm, '-rf', remote_db_file
+
+        upload! sql_string, remote_db_file
+        execute :mysql,
+                "--default-character-set=#{db_settings.fetch(:charset)}",
+                '-u', db_settings.fetch(:username),
+                '-p',
+                '-h', db_settings.fetch(:host), '-P', db_settings.fetch(:port), db_settings.fetch(:name),
+                '-e', "'source #{remote_db_file}'",
+                interaction_handler: Dkdeploy::InteractionHandler::MySql.new(db_settings.fetch(:password))
+      ensure
+        execute :rm, '-rf', remote_db_file
+      end
+    end
+  end
+end


### PR DESCRIPTION
The InteractionHandler was simply swallowing any error messages, for example error codes that were sent from server.
