### PR TITLE
disable BlockLength rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,5 @@ BracesAroundHashParameters:
   Enabled: false
 CyclomaticComplexity:
   Max: 10
+Metrics/BlockLength:
+  Enabled: false


### PR DESCRIPTION
disabled the BlockLength check, that was added in recent rubocop.

We have a lot of capistrano DSL blocks that are very long, so this rule does not make much sense for `dkdeploy´

https://github.com/bbatsov/rubocop/issues/3566
