### PR TITLE
Fix the crash error in add_default_content task

### DIFF
--- a/lib/dkdeploy/tasks/assets.rake
+++ b/lib/dkdeploy/tasks/assets.rake
@@ -87,10 +87,8 @@ namespace :assets do
     asset_default_content = ask_array_variable(args, :asset_default_content, 'questions.asset_default_content')
 
     config_path = File.join 'config', 'preseed'
-    on release_roles :web do
-      asset_default_content.each do |asset|
-        assets_upload asset, config_path
-      end
+    asset_default_content.each do |asset|
+      assets_upload asset, config_path
     end
   end
 end


### PR DESCRIPTION
Fix the crash error in add_default_content task, removing the incorrectly used target server, the task should be executed on.

Resolves #18 