### PR TITLE
fixes IO error for assets:add_default_content task

### DIFF
--- a/lib/dkdeploy/core/version.rb
+++ b/lib/dkdeploy/core/version.rb
@@ -5,7 +5,7 @@ module Dkdeploy
     class Version
       MAJOR = 8
       MINOR = 0
-      PATCH = 0
+      PATCH = 1
 
       def self.to_s
         [MAJOR, MINOR, PATCH].join('.')

--- a/lib/dkdeploy/tasks/assets.rake
+++ b/lib/dkdeploy/tasks/assets.rake
@@ -87,10 +87,8 @@ namespace :assets do
     asset_default_content = ask_array_variable(args, :asset_default_content, 'questions.asset_default_content')
 
     config_path = File.join 'config', 'preseed'
-    on release_roles :web do
-      asset_default_content.each do |asset|
-        assets_upload asset, config_path
-      end
+    asset_default_content.each do |asset|
+      assets_upload asset, config_path
     end
   end
 end


### PR DESCRIPTION
This is a hot fix release v8.0.1 to avoid IO errors when calling task `assets:add_default_content`. This is already solved in `develop` with 730b6298d70e.

referencing GH-25