### PR TITLE
Always execute tasks for each server or at rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use correct capistrano context at copy scm
 - Update capistrano 3.10.1
+- Always execute tasks for each server or at rollback
 
 ## [9.0.0]
 ### Summary

--- a/lib/dkdeploy/dsl.rb
+++ b/lib/dkdeploy/dsl.rb
@@ -6,15 +6,14 @@ module Dkdeploy
     # @param server [Capistrano::Configuration::Server] Server to execute task
     # @param task [String] Name of rake/capistrano task
     # @param args [Array] Arguments of rake/capistrano task
-    def invoke_for_server(server, task, *args) # rubocop:disable Metrics/AbcSize
+    def invoke_for_server(server, task, *args)
       backup_filter = fetch :filter, {}
       new_server_filter = Marshal.load(Marshal.dump(backup_filter))
       new_server_filter[:host] = server.hostname
       set :filter, new_server_filter
       env.setup_filters
       info I18n.t('dsl.invoke_for_server.set_filter', task: task, host: server.hostname, scope: :dkdeploy)
-      invoke task, *args
-      Rake::Task[task].reenable
+      invoke! task, *args
     ensure
       set :filter, backup_filter
       env.setup_filters

--- a/lib/dkdeploy/tasks/deploy.rake
+++ b/lib/dkdeploy/tasks/deploy.rake
@@ -22,7 +22,7 @@ namespace :deploy do
       end
     end
     # Backup and remove last release
-    invoke 'deploy:cleanup_rollback'
+    invoke! 'deploy:cleanup_rollback'
 
     run_locally do
       error I18n.t('rollback_tasks', tasks_for_rollback: tasks_for_rollback.join(', '), scope: :dkdeploy) unless tasks_for_rollback.empty?
@@ -33,8 +33,7 @@ namespace :deploy do
       next unless Rake::Task.task_defined? task_name
 
       # call rollback task
-      Rake::Task[task_name].reenable
-      invoke task_name
+      invoke! task_name
     end
 
     run_locally do


### PR DESCRIPTION
Prevent error at rollback

```
rations'" 1>&2; false; fi stdout: Nothing written
if test ! -d /var/www/dkdeploy/shared/migrations; then echo "Directory does not exist '/var/www/dkdeploy/shared/migrations'" 1>&2; false; fi stderr: Directory does not exist '/var/www/dkdeploy/shared/migrations'
00:24 deploy:failed
      ERROR Error occurred at deployment. Rollback to old release
      Invoking task 'deploy:revert_release' for server 'dkdeploy-typo3-cms.dev'
00:24 deploy:revert_release
      Invoking task 'deploy:symlink:release' for server 'dkdeploy-typo3-cms.dev'
Skipping task `deploy:symlink:release'.
Capistrano tasks may only be invoked once. Since task `deploy:symlink:release' was previously invoked, invoke("deploy:symlink:release") at /Volumes/Development/intellij/dkd/dkdeploy-repositories/dkdeploy-typo3-cms/lib/dkdeploy/typo3/cms/dsl.rb:18 will be skipped.
If you really meant to run this task again, use invoke!("deploy:symlink:release")
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.
https://github.com/capistrano/capistrano/issues/1686
```
