### PR TITLE
[TASK] add constant public_path and use it to construct local_web_root_path

### DIFF
--- a/lib/capistrano/dkdeploy/core.rb
+++ b/lib/capistrano/dkdeploy/core.rb
@@ -31,7 +31,15 @@ after 'deploy:symlink:linked_files', 'deploy:enhanced_symlinks:symlink:linked_fi
 namespace :load do
   task :defaults do
     # Set default web root paths
-    set(:local_web_root_path, -> { fetch(:copy_source) })
+
+    set(:local_web_root_path, lambda do
+      public_path = fetch(:public_path, nil)
+      if public_path.nil?
+        fetch(:copy_source)
+      else
+        File.join(fetch(:copy_source), public_path)
+      end
+    end)
     set :remote_web_root_path, '.'
 
     # Set default version file path

--- a/lib/dkdeploy/constants.rb
+++ b/lib/dkdeploy/constants.rb
@@ -13,6 +13,14 @@ module Dkdeploy
       fetch :copy_source, '.'
     end
 
+    # Public path
+    # Path to folder inside copy source that will be publicly exposed.
+    #
+    # @return [String]
+    def public_path
+      release_path.join(fetch(:public_path, ''))
+    end
+
     # Local Dump Path
     #
     # @return [String]


### PR DESCRIPTION
This is done to make the public path inside the release configurable.
Public path defaults to release_path, if :public is not set. Thus
using public_path over release_path or current_path is backwards compatible.