### PR TITLE
call 'test' independent of shell

### DIFF
--- a/lib/dkdeploy/tasks/current_folder.rake
+++ b/lib/dkdeploy/tasks/current_folder.rake
@@ -6,7 +6,7 @@ namespace :current_folder do
   desc "Delete current folder unless it's a symlink"
   task :remove_unlesss_symlinked do
     on release_roles :all do
-      if test "[[ -d #{current_path} && ! -L #{current_path} ]]"
+      if test "[ -d #{current_path} && ! -L #{current_path} ]"
         execute :rm, '-rf', current_path
       else
         info I18n.t('info.ignoring_current_folder', scope: :dkdeploy)


### PR DESCRIPTION
fixes [#43] - 'test' was called with implicit bash syntax,
this commit makes this call independent of shell